### PR TITLE
NIAD-2736: Fixing SSL workflow stability

### DIFF
--- a/deploy/terraform/database.tf
+++ b/deploy/terraform/database.tf
@@ -9,7 +9,7 @@ resource "aws_db_instance" "ps_db" {
   identifier        = "ps-db"
   allocated_storage = 10
   engine            = "postgres"
-  engine_version    = "14.3"
+  engine_version    = "14.7"
   instance_class    = "db.t3.micro"
   username          = "postgres"
   password          = var.POSTGRES_PASSWORD

--- a/deploy/terraform/network.tf
+++ b/deploy/terraform/network.tf
@@ -199,10 +199,10 @@ resource "aws_security_group" "ps_db_sg" {
   vpc_id      = aws_vpc.nia_gp2gp_vpc.id
 
   ingress {
-    description     = "Allow PS DB traffic"
-    from_port       = var.PS_DB_PORT
-    protocol        = "tcp"
-    to_port         = var.PS_DB_PORT
+    description = "Allow PS DB traffic"
+    from_port   = var.PS_DB_PORT
+    protocol    = "tcp"
+    to_port     = var.PS_DB_PORT
     cidr_blocks = ["0.0.0.0/0"]
   }
 
@@ -245,6 +245,7 @@ resource "aws_lb_target_group" "nia_gp2gp_target_group_inbound" {
 
   health_check {
     enabled  = true
+    port     = var.http_server_port
     interval = 300
     path     = "/healthcheck"
     matcher  = "200-499"

--- a/deploy/terraform/outputs.tf
+++ b/deploy/terraform/outputs.tf
@@ -6,12 +6,12 @@ output "web_public_dns" {
 }
 
 output "s3_state_bucket_arn" {
-  value = aws_s3_bucket.ps_adaptors_tf_state.arn
+  value       = aws_s3_bucket.ps_adaptors_tf_state.arn
   description = "The ARN of S3 state bucket"
 }
 
 output "dynamodb_state_table_name" {
-  value = aws_dynamodb_table.ps_adaptors_tf_locks.name
+  value       = aws_dynamodb_table.ps_adaptors_tf_locks.name
   description = "The name of DynamoDB state table"
 }
 


### PR DESCRIPTION
SSL has been unstable when MHS_INBOUND_USE_SSL is set to "True". This PR aim to bring more stability to ECS infrastructure and SSL workflow as well via making ELB healthchecks more reliable. 